### PR TITLE
[Week2] 공통과제

### DIFF
--- a/src/main/kotlin/baekjoon/DP/01타일.kt
+++ b/src/main/kotlin/baekjoon/DP/01타일.kt
@@ -1,0 +1,26 @@
+package baekjoon.DP
+
+// boj 1904
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val bw = System.out.bufferedWriter()
+    val n = br.readLine().toInt()
+    val dp = Array(n + 1) { 0 }
+
+    dp[1] = 1
+
+    if (n >= 2) {
+        dp[2] = 2
+        if (n >= 3) {
+            for (i in 3..n) {
+                dp[i] = (dp[i - 1] + dp[i - 2]) % 15746
+            }
+        }
+    }
+
+    bw.write(dp[n].toString())
+    bw.flush()
+    bw.close()
+}
+

--- a/src/main/kotlin/baekjoon/구현/기적의매매법.kt
+++ b/src/main/kotlin/baekjoon/구현/기적의매매법.kt
@@ -1,4 +1,4 @@
-package 구현
+package baekjoon.구현
 
 // boj 20546
 

--- a/src/main/kotlin/baekjoon/분할정복/종이의개수.kt
+++ b/src/main/kotlin/baekjoon/분할정복/종이의개수.kt
@@ -1,0 +1,55 @@
+package baekjoon.분할정복
+
+// boj 1780
+val br = System.`in`.bufferedReader()
+val bw = System.out.bufferedWriter()
+val totalPaperCount = br.readLine().toInt()
+val paperArr = Array(totalPaperCount) { br.readLine().split(" ").map { it.toInt() }.toIntArray() }
+
+/*
+index 0 이 -1의 개수, 1이 0의 개수, 2가 1의 개수
+ */
+val resultArr = Array(3) { 0 }
+
+
+fun main() {
+    checkPaper(totalPaperCount, 0, 0)
+
+    bw.write("${resultArr[0]} \n${resultArr[1]} \n${resultArr[2]}")
+    bw.flush()
+    bw.close()
+
+}
+
+fun checkPaper(paperSize: Int, rowStartIndex: Int, colStartIndex: Int) {
+    val firstNum = paperArr[rowStartIndex][colStartIndex]
+
+    if (paperSize == 1) {
+        resultArr[firstNum + 1] += 1
+        return
+    }
+
+    for (i in rowStartIndex until rowStartIndex + paperSize) {
+        for (j in colStartIndex until colStartIndex + paperSize) {
+            if (paperArr[i][j] != firstNum) {
+                cropPaper(paperSize, rowStartIndex, colStartIndex)
+                return
+            }
+        }
+    }
+
+    resultArr[firstNum + 1] += 1
+}
+
+fun cropPaper(paperSize: Int, rowStartIndex: Int, colStartIndex: Int) {
+    val cropTargetSize = paperSize / 3
+    for (i in 0..2) {
+        for (j in 0..2) {
+            checkPaper(
+                cropTargetSize,
+                rowStartIndex + cropTargetSize * i,
+                colStartIndex + cropTargetSize * j
+            )
+        }
+    }
+}

--- a/src/main/kotlin/baekjoon/이분탐색/예산.kt
+++ b/src/main/kotlin/baekjoon/이분탐색/예산.kt
@@ -1,0 +1,45 @@
+package baekjoon.이분탐색
+
+// boj 2512
+
+val br = System.`in`.bufferedReader()
+val bw = System.out.bufferedWriter()
+val n = br.readLine().toInt()
+val requests = br.readLine().split(" ").map { it.toInt() }.toIntArray()
+
+fun main() {
+    val maxBudget = br.readLine().toInt()
+
+    var start = 0
+    var end = requests.max()
+    var result = 0
+
+    while (start <= end) {
+        val mid = (start + end) / 2
+
+        if (calculateBudget(mid) > maxBudget) {
+            end = mid - 1
+        } else {
+            start = mid + 1
+            result = mid
+        }
+
+    }
+
+    bw.write(result.toString())
+    bw.flush()
+    bw.close()
+
+}
+
+fun calculateBudget(budget: Int): Long {
+    var totalBudget = 0L
+    for (i in 0 until n) {
+        totalBudget += if (budget > requests[i]) {
+            requests[i].toLong()
+        } else {
+            budget.toLong()
+        }
+    }
+    return totalBudget
+}


### PR DESCRIPTION
# [Chapter 4 - 분할 정복]
## ❓ 문제 번호

- [종이의 개수(1780)](https://www.acmicpc.net/problem/1780)

## ❗풀이 방법 & 고민한 점

- 코틀린에서는 -1로 인덱스 접근을 할 수 없기 때문에 -1, 0, 1의 경우에 +1 을 해주어서 0,1,2 인덱스로 사용했습니다.
- 처음 입력 받은 종이는 불변으로 유지하고 인덱스를 조작하며 재귀 형식으로 풀었습니다.
- 종이 안에 있는 숫자가 모두 같은 숫자로 이뤄져있는지 먼저 확인하고, 그렇지 않으면 종이를 자르는 함수를 호출합니다.
- 종이는 무조건 9번 짜르기에 인덱스를 적절히 계산하여 다시 체킹하는 함수를 호출했습니다. 

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 서칭 안하고 푸니까 제 풀이가 분할 정복 어쩌구인지 잘 모르겠네요.. 맞겠죠? 
- 버퍼를 사용해서 입출력을 하였는데, 더 좋은 방법이 있나요? 버퍼 문법도 살짝씩 다른 것 같네요..!
- 테블릿에 수도 코드를 작성하며 푸니 생각보다 설계가 수월하게 됐네요 ㅎㅎ
- 시간이 꽤 오래걸렸는데, 시간 단축하는 팁이 있을까요? 

### 고통 받은 점

- 숫자의 개수가 아니라, 종이의 개수네..............요 이거 때문에 영겁의 시간 날림

# [Chapter5 - 동적 계획법]
## ❓ 문제 번호

- [01타일(1904)](https://www.acmicpc.net/problem/1904)

## ❗풀이 방법 & 고민한 점

- n - 2 타일에 00을 붙이고 n - 1 타일에 1을 붙이는 두 가지 경우를 더하는 방식으로 점화식을 구성했습니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 초기값 설정 부분과 if문 for문 중첩을 좀 더 깔끔하게 나타내보고 싶은데 어떻게 하면 좋을까요?

# [Chapter6 - 이분 탐색]
## ❓ 문제 번호

- [예산(2512)](https://www.acmicpc.net/problem/2512)

## ❗풀이 방법 & 고민한 점

- 이분 탐색으로 예산 요청을 최대한 다 줄 수 있게 국가 총 예산을 부여했습니다.
- 처음에는 국가 총 예산을 기준으로 배열을 생성했는데, 생각해보니 연속된 수의 배열이라 그냥 배열을 생성하지 않고 숫자를 그대로 사용했습니다. 따라서 정렬할 필요도 없었습니다.
- 예산을 계산하는 과정 역시 한 원소씩 비교하고 계산하므로 정렬이 필요하지 않습니다. 이때 자료형은 Long을 사용했습니다.(이거 때문에 4번 틀림..)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 이분 탐색은 인덱스를 비교하고 조정하는 것을 섬세하게 잘 해야 하네요..
- 인트 오버플로우 조심합시다!
